### PR TITLE
Fix missing docstring in generated docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-EmailScraper = "4bfef8eb-d10e-4c1e-a6a0-b774b262ad28"
 
 [compat]
 Documenter = "0.27"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,5 @@
 # EmailScraper.jl Documentation
 
 ```@docs
-EmailScraper.scrape_url(x)
+scrape_url
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,5 @@
 # EmailScraper.jl Documentation
 
 ```@docs
-scrape_url(x)
+EmailScraper.scrape_url(x)
 ```


### PR DESCRIPTION
Maybe, the entry in docs/project.toml is the reason that it breaks